### PR TITLE
Fix worker draining

### DIFF
--- a/modules/worker/cloud-config.yml
+++ b/modules/worker/cloud-config.yml
@@ -65,8 +65,8 @@ write_files:
       ExecStart=/usr/local/bin/concourse worker
 
       ExecStop=/usr/local/bin/concourse retire-worker
-      ExecStop=/bin/bash -c "while ! /usr/local/bin/concourse retire-worker | grep worker-not-found > /dev/null; do sleep 5; done"
-      ExecStop=/bin/kill -s TERM $MAINPID
+      ExecStop=/bin/bash -c "while pgrep concourse; do sleep 5; done"
+      ExecStop=/bin/kill -s TERM -- $MAINPID
 
       [Install]
       WantedBy=multi-user.target

--- a/modules/worker/cloud-config.yml
+++ b/modules/worker/cloud-config.yml
@@ -52,6 +52,7 @@ write_files:
 
       Environment="CONCOURSE_TEAM=${worker_team}"
       Environment="CONCOURSE_BIND_IP=0.0.0.0"
+      Environment="CONCOURSE_LOG_LEVEL=${log_level}"
       Environment="CONCOURSE_WORK_DIR=/concourse"
       Environment="CONCOURSE_TSA_HOST=${tsa_host}:${tsa_port}"
       Environment="CONCOURSE_BAGGAGECLAIM_BIND_IP=0.0.0.0"

--- a/modules/worker/cloud-config.yml
+++ b/modules/worker/cloud-config.yml
@@ -49,6 +49,7 @@ write_files:
       RestartSec=30s
       TimeoutStartSec=5m
       TimeoutStopSec=1h
+      KillMode=process
 
       Environment="CONCOURSE_TEAM=${worker_team}"
       Environment="CONCOURSE_BIND_IP=0.0.0.0"
@@ -65,8 +66,7 @@ write_files:
       ExecStart=/usr/local/bin/concourse worker
 
       ExecStop=/usr/local/bin/concourse retire-worker
-      ExecStop=/bin/bash -c "while pgrep concourse; do sleep 5; done"
-      ExecStop=/bin/kill -s TERM -- $MAINPID
+      ExecStop=/bin/bash -c "while pgrep concourse >> /dev/null; do echo draining worker... && sleep 5; done; echo done draining!"
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
Apparently the behaviour for `retire-worker` has had an undocumented change where it no longer outputs `worker-not-found`, which effectively turned our little `ExecStop` into an infinite loop.

After some trial and error I've figured out that `retire-worker` actually shuts down the worker process automatically after successfully draining it. Hence, all we need is a `pgrep concourse`-loop to wait for the process to shut down.