### PR TITLE
Fix lifecycled systemd unit

### DIFF
--- a/modules/worker/cloud-config.yml
+++ b/modules/worker/cloud-config.yml
@@ -114,7 +114,8 @@ write_files:
 
       [Service]
       Type=simple
-      Restart=always
+      Restart=on-failure
+      RestartSec=30s
       TimeoutSec=infinity
 
       Environment="AWS_REGION=${region}"


### PR DESCRIPTION
Why?

- We don't want `lifecycled` to restart after it has handled a lifecycle hook.
- And if it fails, there is no point in restarting immediately since the SQS queue cannot be recreated until 1min after being deleted (which happens when it shuts down).