### PR TITLE
Enable Concourse secret cache

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,3 +73,6 @@ tasks:
     cmds:
     - packer validate -var="template_version={{.VERSION}}" packer/template.json
     - packer build -var="template_version={{.VERSION}}" packer/template.json
+    vars:
+      VERSION:
+        sh: git describe --tags --candidates=1 --dirty

--- a/modules/atc/main.tf
+++ b/modules/atc/main.tf
@@ -99,6 +99,7 @@ locals {
     prometheus_enabled     = var.prometheus_enabled
     prometheus_bind_port   = var.prometheus_port
     placement_strategy     = var.placement_strategy
+    secret_cache_enabled   = var.secret_cache_enabled
     concourse_web_host     = "${lower(var.web_protocol)}://${var.domain != "" ? var.domain : module.external_lb.dns_name}:${var.web_port}"
     postgres_host          = var.postgres_host
     postgres_port          = var.postgres_port

--- a/modules/atc/variables.tf
+++ b/modules/atc/variables.tf
@@ -181,6 +181,12 @@ variable "placement_strategy" {
   default     = "volume-locality"
 }
 
+variable "secret_cache_enabled" {
+  description = "Enable Concourse secret cache."
+  type        = bool
+  default     = true
+}
+
 variable "encryption_key" {
   description = "A 16 or 32 length key used to encrypt sensitive information before storing it in the database."
   type        = string

--- a/modules/cloud-init/atc.yml
+++ b/modules/cloud-init/atc.yml
@@ -48,6 +48,7 @@ write_files:
       Environment="CONCOURSE_OLD_ENCRYPTION_KEY=${old_encryption_key}"
       Environment="CONCOURSE_AWS_SECRETSMANAGER_REGION=${region}"
       Environment="CONCOURSE_CONTAINER_PLACEMENT_STRATEGY=${placement_strategy}"
+      Environment="CONCOURSE_SECRET_CACHE_ENABLED=${secret_cache_enabled}"
 
       %{ if local_user != "" }Environment="CONCOURSE_ADD_LOCAL_USER=${local_user}"%{ endif }
       %{ if local_admin_user != "" }Environment="CONCOURSE_MAIN_TEAM_LOCAL_USER=${local_admin_user}"%{ endif }

--- a/test/module.go
+++ b/test/module.go
@@ -37,7 +37,7 @@ func RunTestSuite(t *testing.T, endpoint, atcASGName, workerASGName, adminUser, 
 
 	// Wait for ATC to register as healthy in the target groups (max 10min wait)
 	sess := NewSession(t, region)
-	WaitForHealthyTargets(t, sess, atcASGName, 20*time.Second, 10*time.Minute)
+	WaitForHealthyTargets(t, sess, atcASGName, 1*time.Minute, 15*time.Minute)
 
 	info := GetConcourseInfo(t, endpoint)
 	assert.Equal(t, expected.Version, info.Version)

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -62,6 +62,7 @@ func TestModule(t *testing.T) {
 						`Environment="CONCOURSE_ENCRYPTION_KEY="`,
 						`Environment="CONCOURSE_OLD_ENCRYPTION_KEY="`,
 						`Environment="CONCOURSE_AWS_SECRETSMANAGER_REGION=eu-west-1"`,
+						`Environment="CONCOURSE_SECRET_CACHE_ENABLED=true"`,
 					},
 					IsGzippedUserData: true,
 				},


### PR DESCRIPTION
I'm increasing the timeout and interval when waiting for healthy targets during e2e tests because the RDS instances were taking longer than usual to boot, which led to longer startup times for Concourse as well, which in turn meant that health checks were taking longer to pass.