### PR TITLE
Fix disk metrics to only be collected for root

### DIFF
--- a/modules/cloud-init/shared.yml
+++ b/modules/cloud-init/shared.yml
@@ -27,7 +27,7 @@ write_files:
               "metrics_collected": {
                   "disk": {
                       "resources": [
-                          "*"
+                          "/"
                       ],
                       "measurement": [
                           "disk_used_percent"


### PR DESCRIPTION
Right now, disk metrics are also being collected for temporary volumes on the Concourse workers (i.e. all container volumes). This makes it so that the disk metrics are only collected for `/` and saves a lot of $$$ on CloudWatch.